### PR TITLE
refactor: replace map with multimap for HTTP headers

### DIFF
--- a/include/HttpRequest.hpp
+++ b/include/HttpRequest.hpp
@@ -9,11 +9,11 @@ class HttpRequest
 {
   public:
 	HttpRequest(
-		std::string						   &method,
-		std::string						   &httpVersion,
-		std::string						   &target,
-		std::map<std::string, std::string> &headers,
-		std::vector<char>				   &body
+		std::string								&method,
+		std::string								&httpVersion,
+		std::string								&target,
+		std::multimap<std::string, std::string> &headers,
+		std::vector<char>						&body
 	);
 	HttpRequest(const HttpRequest &src);
 	~HttpRequest(void);
@@ -22,25 +22,25 @@ class HttpRequest
 	void setMethod(std::string &newMethod);
 	void setHttpVersion(std::string &newHttpVersion);
 	void setTarget(std::string &newTarget);
-	void setHeaders(std::map<std::string, std::string> &newHeaders);
+	void setHeaders(std::multimap<std::string, std::string> &newHeaders);
 	void setBody(std::vector<char> &newBody);
 
 	// Getters
-	const std::string						 &getMethod(void) const;
-	const std::string						 &getHttpVersion(void) const;
-	const std::string						 &getTarget(void) const;
-	const std::map<std::string, std::string> &getHeaders(void) const;
-	const std::vector<char>					 &getBody(void) const;
+	const std::string							  &getMethod(void) const;
+	const std::string							  &getHttpVersion(void) const;
+	const std::string							  &getTarget(void) const;
+	const std::multimap<std::string, std::string> &getHeaders(void) const;
+	const std::vector<char>						  &getBody(void) const;
 
 	// Overloaded Operators
 	HttpRequest &operator=(const HttpRequest &rhs);
 
   private:
-	std::string						   method_;
-	std::string						   httpVersion_;
-	std::string						   target_;
-	std::map<std::string, std::string> headers_;
-	std::vector<char>				   body_;
+	std::string								method_;
+	std::string								httpVersion_;
+	std::string								target_;
+	std::multimap<std::string, std::string> headers_;
+	std::vector<char>						body_;
 };
 
 std::ostream &operator<<(std::ostream &os, const HttpRequest &rhs);

--- a/include/RequestParser.hpp
+++ b/include/RequestParser.hpp
@@ -29,12 +29,12 @@ class RequestParser
 	static void checkHttpVersion(std::string &httpVersion);
 
 	// Headers checks
-	void checkHeaders(const std::map<std::string, std::string> &headers);
+	void checkHeaders(const std::multimap<std::string, std::string> &headers);
 
 	// Body checks
 	void checkBody(
-		const std::string						 &method,
-		const std::map<std::string, std::string> &headers,
-		const std::string						 &body
+		const std::string							  &method,
+		const std::multimap<std::string, std::string> &headers,
+		const std::string							  &body
 	);
 };

--- a/srcs/HttpRequest.cpp
+++ b/srcs/HttpRequest.cpp
@@ -2,11 +2,11 @@
 #include <ostream>
 
 HttpRequest::HttpRequest(
-	std::string&						method,
-	std::string&						httpVersion,
-	std::string&						target,
-	std::map<std::string, std::string>& headers,
-	std::vector<char>&					body
+	std::string								&method,
+	std::string								&httpVersion,
+	std::string								&target,
+	std::multimap<std::string, std::string> &headers,
+	std::vector<char>						&body
 )
 	: method_(method), httpVersion_(httpVersion), target_(target),
 	  headers_(headers), body_(body)
@@ -14,7 +14,7 @@ HttpRequest::HttpRequest(
 	return;
 }
 
-HttpRequest::HttpRequest(const HttpRequest& src)
+HttpRequest::HttpRequest(const HttpRequest &src)
 {
 	method_ = src.method_;
 	httpVersion_ = src.httpVersion_;
@@ -45,7 +45,8 @@ void HttpRequest::setTarget(std::string &newTarget)
 	target_ = newTarget;
 }
 
-void HttpRequest::setHeaders(std::map<std::string, std::string> &newHeaders)
+void HttpRequest::setHeaders(std::multimap<std::string, std::string> &newHeaders
+)
 {
 	headers_ = newHeaders;
 }
@@ -55,51 +56,55 @@ void HttpRequest::setBody(std::vector<char> &newBody)
 	body_ = newBody;
 }
 
-const std::string& HttpRequest::getMethod(void) const
+const std::string &HttpRequest::getMethod(void) const
 {
 	return method_;
 }
 
-const std::string& HttpRequest::getHttpVersion(void) const
+const std::string &HttpRequest::getHttpVersion(void) const
 {
 	return httpVersion_;
 }
 
-const std::string& HttpRequest::getTarget(void) const
+const std::string &HttpRequest::getTarget(void) const
 {
 	return target_;
 }
 
-const std::map<std::string, std::string>& HttpRequest::getHeaders(void) const
+const std::multimap<std::string, std::string> &HttpRequest::getHeaders(void
+) const
 {
 	return headers_;
 }
 
-const std::vector<char>& HttpRequest::getBody(void) const
+const std::vector<char> &HttpRequest::getBody(void) const
 {
 	return body_;
 }
 
-std::ostream& operator<<(std::ostream& os, const HttpRequest& rhs)
+std::ostream &operator<<(std::ostream &os, const HttpRequest &rhs)
 {
-    os << "Method: " << rhs.getMethod() << std::endl;
-    os << "HTTP version: " << rhs.getHttpVersion() << std::endl;
-    os << "Target: " << rhs.getTarget() << std::endl;
+	os << "Method: " << rhs.getMethod() << std::endl;
+	os << "HTTP version: " << rhs.getHttpVersion() << std::endl;
+	os << "Target: " << rhs.getTarget() << std::endl;
 	os << "HEADERS:" << std::endl;
-    const std::map<std::string, std::string>& headersCpy = rhs.getHeaders();
-    for (std::map<std::string, std::string>::const_iterator it = headersCpy.begin();
-         it != headersCpy.end();
-         it++)
-    {
-        os << it->first << " : " << it->second << std::endl;
-    }
+	const std::multimap<std::string, std::string> &headersCpy
+		= rhs.getHeaders();
+	for (std::multimap<std::string, std::string>::const_iterator it
+		 = headersCpy.begin();
+		 it != headersCpy.end();
+		 it++)
+	{
+		os << it->first << " : " << it->second << std::endl;
+	}
 	os << "BODY:" << std::endl;
-    const std::vector<char>& bodyCpy = rhs.getBody();
-    for (std::vector<char>::const_iterator it = bodyCpy.begin(); it != bodyCpy.end();
-         it++)
-    {
-        os << *it << std::endl;
-    }
+	const std::vector<char> &bodyCpy = rhs.getBody();
+	for (std::vector<char>::const_iterator it = bodyCpy.begin();
+		 it != bodyCpy.end();
+		 it++)
+	{
+		os << *it << std::endl;
+	}
 
-    return os;
+	return os;
 }

--- a/tests/HttpRequestTest.cpp
+++ b/tests/HttpRequestTest.cpp
@@ -2,15 +2,22 @@
 
 Test(HttpRequest, testHttpRequest)
 {
-	char** argv = new char*[2];
-	argv[0] = (char*)"./server";
-	argv[1] = (char*)"test.config";
-	std::string						   method("GET");
-	std::string						   httpVersion("HTTP/1.1");
-	std::string						   target("localhost:8080");
-	std::map<std::string, std::string> headers;
-	headers["Content-Type"] = "application/json";
-	headers["Authorization"] = "Bearer token";
+	char **argv = new char *[2];
+	argv[0] = (char *)"./server";
+	argv[1] = (char *)"test.config";
+	std::string								method("GET");
+	std::string								httpVersion("HTTP/1.1");
+	std::string								target("localhost:8080");
+	std::multimap<std::string, std::string> headers;
+	headers.insert(
+		std::pair<std::string, std::string>("Host", "www.example.com")
+	);
+	headers.insert(
+		std::pair<std::string, std::string>("Content-Type", "application/json")
+	);
+	headers.insert(
+		std::pair<std::string, std::string>("Authorization", "Bearer token")
+	);
 	std::vector<char> body({'h', 'e', 'l', 'l', 'o'});
 
 	// create simple request object
@@ -20,10 +27,11 @@ Test(HttpRequest, testHttpRequest)
 	cr_assert_str_eq(request.getHttpVersion().c_str(), "HTTP/1.1");
 	cr_assert_str_eq(request.getTarget().c_str(), "localhost:8080");
 	cr_assert_str_eq(
-		request.getHeaders().at("Content-Type").c_str(), "application/json"
+		request.getHeaders().find("Content-Type")->second.c_str(),
+		"application/json"
 	);
 	cr_assert_str_eq(
-		request.getHeaders().at("Authorization").c_str(), "Bearer token"
+		request.getHeaders().find("Authorization")->second.c_str(), "Bearer token"
 	);
 	cr_assert_eq(request.getBody(), body);
 }

--- a/tests/RequestParserTest.cpp
+++ b/tests/RequestParserTest.cpp
@@ -2,85 +2,106 @@
 
 Test(RequestParser, testStartLine)
 {
-    // Setup code...
-    char** argv = new char*[2];
-    argv[0] = (char*)"./server";
-    argv[1] = (char*)"test.config";
-    std::string method("GET");
-    std::string httpVersion("HTTP/1.1");
-    std::string target("/index.html");
-    std::map<std::string, std::string> headers;
-    headers["Host"] = "www.example.com";
-    headers["User-Agent"] = "telnet/12.21";
-    headers["Accept"] = "*/*";
-    std::vector<char> body;
+	// Setup code...
+	char **argv = new char *[2];
+	argv[0] = (char *)"./server";
+	argv[1] = (char *)"test.config";
+	std::string								method("GET");
+	std::string								httpVersion("HTTP/1.1");
+	std::string								target("/index.html");
+	std::multimap<std::string, std::string> headers;
+	headers.insert(
+		std::pair<std::string, std::string>("Host", "www.example.com")
+	);
+	headers.insert(
+		std::pair<std::string, std::string>("User-Agent", "telnet/12.21")
+	);
+	headers.insert(std::pair<std::string, std::string>("Accept", "*/*"));
+	std::vector<char> body;
 
-    // Create request string with start line
-    std::string requestStr = method + " " + target + " " + httpVersion + "\r\n";
+	// Create request string with start line
+	std::string requestStr = method + " " + target + " " + httpVersion + "\r\n";
 
-    // Parse request
-    HttpRequest request = RequestParser::parseRequest(requestStr);
+	// Parse request
+	HttpRequest request = RequestParser::parseRequest(requestStr);
 
-    // Assertions for start line
-    cr_assert_str_eq(request.getMethod().c_str(), method.c_str());
-    cr_assert_str_eq(request.getHttpVersion().c_str(), httpVersion.c_str());
-    cr_assert_str_eq(request.getTarget().c_str(), target.c_str());
+	// Assertions for start line
+	cr_assert_str_eq(request.getMethod().c_str(), method.c_str());
+	cr_assert_str_eq(request.getHttpVersion().c_str(), httpVersion.c_str());
+	cr_assert_str_eq(request.getTarget().c_str(), target.c_str());
 }
 
 Test(RequestParser, testHeaders)
 {
-    // Setup code...
-    char** argv = new char*[2];
-    argv[0] = (char*)"./server";
-    argv[1] = (char*)"test.config";
-    std::string method("GET");
-    std::string httpVersion("HTTP/1.1");
-    std::string target("/index.html");
-    std::map<std::string, std::string> headers;
-    headers["Host"] = "www.example.com";
-    headers["User-Agent"] = "telnet/12.21";
-    headers["Accept"] = "*/*";
-    std::vector<char> body;
+	// Setup code...
+	char **argv = new char *[2];
+	argv[0] = (char *)"./server";
+	argv[1] = (char *)"test.config";
+	std::string								method("GET");
+	std::string								httpVersion("HTTP/1.1");
+	std::string								target("/index.html");
+	std::multimap<std::string, std::string> headers;
+	headers.insert(
+		std::pair<std::string, std::string>("Host", "www.example.com")
+	);
+	headers.insert(
+		std::pair<std::string, std::string>("User-Agent", "telnet/12.21")
+	);
+	headers.insert(std::pair<std::string, std::string>("Accept", "*/*"));
+	std::vector<char> body;
 
-    // Create request string with headers
-    std::string requestStr = method + " " + target + " " + httpVersion + "\r\n";
-    for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it)
-    {
-        requestStr += it->first + ": " + it->second + "\r\n";
-    }
+	// Create request string with headers
+	std::string requestStr = method + " " + target + " " + httpVersion + "\r\n";
+	for (std::multimap<std::string, std::string>::const_iterator it
+		 = headers.begin();
+		 it != headers.end();
+		 ++it)
+	{
+		requestStr += it->first + ": " + it->second + "\r\n";
+	}
 
-    // Parse request
-    HttpRequest request = RequestParser::parseRequest(requestStr);
+	// Parse request
+	HttpRequest request = RequestParser::parseRequest(requestStr);
 
-    // Assertions for headers
-    for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it)
-    {
-        cr_assert_str_eq(request.getHeaders().at(it->first).c_str(), it->second.c_str());
-    }
+	// Assertions for headers
+	for (std::multimap<std::string, std::string>::const_iterator it
+		 = headers.begin();
+		 it != headers.end();
+		 ++it)
+	{
+		cr_assert_str_eq(
+			request.getHeaders().find(it->first)->second.c_str(),
+			it->second.c_str()
+		);
+	}
 }
 
 Test(RequestParser, testBody)
 {
-    // Setup code...
-    char** argv = new char*[2];
-    argv[0] = (char*)"./server";
-    argv[1] = (char*)"test.config";
-    std::string method("GET");
-    std::string httpVersion("HTTP/1.1");
-    std::string target("/index.html");
-    std::map<std::string, std::string> headers;
-    headers["Host"] = "www.example.com";
-    headers["User-Agent"] = "telnet/12.21";
-    headers["Accept"] = "*/*";
-    std::vector<char> body;
+	// Setup code...
+	char **argv = new char *[2];
+	argv[0] = (char *)"./server";
+	argv[1] = (char *)"test.config";
+	std::string								method("GET");
+	std::string								httpVersion("HTTP/1.1");
+	std::string								target("/index.html");
+	std::multimap<std::string, std::string> headers;
+	headers.insert(
+		std::pair<std::string, std::string>("Host", "www.example.com")
+	);
+	headers.insert(
+		std::pair<std::string, std::string>("User-Agent", "telnet/12.21")
+	);
+	headers.insert(std::pair<std::string, std::string>("Accept", "*/*"));
+	std::vector<char> body;
 
-    // Create request string with body
-    std::string requestStr = method + " " + target + " " + httpVersion + "\r\n";
-    requestStr += "\r\n" + std::string(body.begin(), body.end());
+	// Create request string with body
+	std::string requestStr = method + " " + target + " " + httpVersion + "\r\n";
+	requestStr += "\r\n" + std::string(body.begin(), body.end());
 
-    // Parse request
-    HttpRequest request = RequestParser::parseRequest(requestStr);
+	// Parse request
+	HttpRequest request = RequestParser::parseRequest(requestStr);
 
-    // Assertions for body
-    cr_assert_eq(request.getBody(), body);
+	// Assertions for body
+	cr_assert_eq(request.getBody(), body);
 }


### PR DESCRIPTION
This commit replaces the std::map used for storing HTTP headers with std::multimap. This change allows for multiple headers with the same name, which is necessary for certain HTTP headers according to the HTTP/1.1 specification.

This commit also updates the RequestParser tests to use std::multimap for headers and adjusts the assertions accordingly.