### PR TITLE
Add server engine deconstruct

### DIFF
--- a/include/HttpResponse.hpp
+++ b/include/HttpResponse.hpp
@@ -22,6 +22,6 @@ class HttpResponse
 	int			statusCode_;
 	std::string reasonPhrase_;
 	// vector of pairs as unordered map only introduced with C++11
-	std::vector<std::pair<std::string, std::string>> headers_;
+	std::vector<std::pair<std::string, std::string> > headers_;
 	std::string										 body_;
 };

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -19,6 +19,8 @@ class Server
 	Server &operator=(const Server &rhs);
 
 	void	initServer(void);
+	void	closeServer(void);
+	void	resetServer(void);
 
 	// Getters
 	unsigned int							 getPort(void) const;

--- a/include/ServerEngine.hpp
+++ b/include/ServerEngine.hpp
@@ -17,7 +17,6 @@ class ServerEngine
 	~ServerEngine();
 
 	void start(void);
-	void restartServer(size_t &index);
 
   private:
 	ServerEngine(ServerEngine const &src);
@@ -31,6 +30,8 @@ class ServerEngine
 	bool isPollFdServer_(int &fd);
 	void handleClient_(size_t &index);
 	void acceptConnection_(size_t &index);
+	void restartServer_(size_t &index);
+	void pollFdError_(size_t &index);
 
 	std::string createResponse(const HttpRequest &request);
 	std::string handleGetRequest(const HttpRequest &request);

--- a/include/ServerEngine.hpp
+++ b/include/ServerEngine.hpp
@@ -4,7 +4,6 @@
 #include "HttpRequest.hpp"
 #include "Server.hpp"
 #include <cstring>
-#include <fstream>
 #include <map>
 #include <poll.h>
 #include <string>
@@ -13,11 +12,12 @@ class ServerEngine
 {
   public:
 	ServerEngine();
-	ServerEngine(std::vector<std::map<std::string, ConfigValue>> const &servers
+	ServerEngine(std::vector<std::map<std::string, ConfigValue> > const &servers
 	);
 	~ServerEngine();
 
 	void start(void);
+	void restartServer(size_t &index);
 
   private:
 	ServerEngine(ServerEngine const &src);

--- a/srcs/HttpResponse.cpp
+++ b/srcs/HttpResponse.cpp
@@ -37,7 +37,7 @@ std::string HttpResponse::toString() const
 				+ "\r\n";
 
 	// Headers
-	std::vector<std::pair<std::string, std::string>>::const_iterator it;
+	std::vector<std::pair<std::string, std::string> >::const_iterator it;
 	for (it = headers_.begin(); it != headers_.end(); ++it)
 	{
 		response += it->first + ": " + it->second + "\r\n";

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1,6 +1,7 @@
 #include "Server.hpp"
 #include "ServerException.hpp"
 #include "utils.hpp"
+#include "Logger.hpp"
 
 #include <fcntl.h>
 #include <netdb.h>
@@ -57,7 +58,12 @@ Server &Server::operator=(const Server &src)
 
 Server::~Server(void)
 {
-	close(serverFd_);
+	// Close the server socket if it is open and set the file descriptor to -1
+	// to indicate that the socket is closed
+	if (serverFd_ >= 0)
+	{
+    this->closeServer();
+	}
 }
 
 void Server::initServer(void)
@@ -65,6 +71,23 @@ void Server::initServer(void)
 	createSocket_();
 	bindSocket_();
 	listenSocket_();
+}
+
+void Server::closeServer(void)
+{
+	Logger::log(Logger::DEBUG) << "Closing server socket" << std::endl;
+	if (serverFd_ >= 0)
+	{
+		close(serverFd_);
+		serverFd_ = -1;
+	}
+}
+
+void Server::resetServer(void)
+{
+	closeServer();
+	Logger::log(Logger::DEBUG) << "initializing server socket" << std::endl;
+	initServer();
 }
 
 void Server::createSocket_()


### PR DESCRIPTION
Changes:

- Close all pollFds_ in the destructor of ServerEngine.
- Add methods closeFd and restartServer in Server.
- If an error occurs in the server socket within ServerEngine, restart the server.