### PR TITLE
Handling signals correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ HEADERS						:= colors.hpp ServerInput.hpp utils.hpp ServerException.hpp \
 										 ServerConfig.hpp ConfigValue.hpp utils.hpp Server.hpp \
 										 HttpRequest.hpp RequestParser.hpp Logger.hpp \
 											HttpException.hpp ServerEngine.hpp \
-											HttpResponse.hpp
+											HttpResponse.hpp signals.hpp
 SOURCE						:= main.cpp ServerInput.cpp ServerException.cpp ServerConfig.cpp \
 										 ConfigValue.cpp utils.cpp Server.cpp HttpRequest.cpp \
 											RequestParser.cpp Logger.cpp HttpException.cpp ServerEngine.cpp \
-											HttpResponse.cpp
+											HttpResponse.cpp signals.cpp
 
 OBJECTS						:= $(addprefix $(OBJ_DIR)/, $(SOURCE:.cpp=.o))
 

--- a/include/signals.hpp
+++ b/include/signals.hpp
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace signals
+{
+/* The server handles the following signals:
+SIGINT, SIGQUIT, SIGTERM, SIGPIPE, SIGHUP */
+void handleSignals(void);
+} // namespace signals

--- a/srcs/ServerInput.cpp
+++ b/srcs/ServerInput.cpp
@@ -105,23 +105,23 @@ std::string ServerInput::getVersionMessage(void) const
 {
 	std::stringstream ss;
 
-	ss << YELLOW BOLD "WebServ " << RESET ULINE CYAN "v0.0.1" << "\n" RESET;
+	ss << YELLOW BOLD "WebServ " << RESET ULINE CYAN "v0.3" << RESET;
 	if (this->hasThisFlag(ServerInput::V_LITE))
 		return ss.str();
 
 #ifdef __clang__
-	ss << WHITE "Compiled with" << YELLOW " Clang "
+	ss << WHITE "\nCompiled with" << YELLOW " Clang "
 	   << WHITE "version " CYAN BOLD << __clang_major__ << "."
 	   << __clang_minor__ << "." << __clang_patchlevel__ << RESET;
 #elif defined(__GNUC__)
-	ss << WHITE "Compiled with " << YELLOW " GCC " << WHITE " version "
+	ss << WHITE "\nCompiled with " << YELLOW " GCC " << WHITE " version "
 	   << CYAN ULINE << __GNUC__ << "." << __GNUC_MINOR__ << "."
 	   << __GNUC_PATCHLEVEL__ << RESET;
 #elif defined(_MSC_VER)
-	ss << WHITE "Compiled with " << YELLOW "MSVC " << WHITE "version " CYAN BOLD
+	ss << WHITE "\nCompiled with " << YELLOW "MSVC " << WHITE "version " CYAN BOLD
 	   << _MSC_VER << RESET;
 #else
-	ss << RED "Unknown compiler" << RESET;
+	ss << RED "\nUnknown compiler" << RESET;
 #endif
 
 	ss << WHITE "\nConfiguration file path: " YELLOW << this->filepath_ << '\n';

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -3,48 +3,68 @@
 #include "ServerEngine.hpp"
 #include "ServerInput.hpp"
 #include "colors.hpp"
+#include "signals.hpp"
 
 #include <iostream>
+
+static bool isHelpOrVersionFlags(ServerInput &input)
+{
+	if (!input.hasThisFlag(ServerInput::HELP)
+		&& !input.hasThisFlag(ServerInput::V_LITE)
+		&& !input.hasThisFlag(ServerInput::V_FULL))
+		return false;
+	// If the user asked for help, print the help message
+	if (input.hasThisFlag(ServerInput::HELP))
+	{
+		std::cout << input.getHelpMessage() << std::endl;
+	}
+	// If the user asked for the version, print the version message
+	if (input.hasThisFlag(ServerInput::V_LITE)
+		|| input.hasThisFlag(ServerInput::V_FULL))
+	{
+		std::cout << input.getVersionMessage() << std::endl;
+	}
+	return true;
+}
+
+static bool isTestMode(ServerInput &input, ServerConfig &config)
+{
+	// If the user asked for a test of the config file, print the config and
+	// exit
+	if (input.hasThisFlag(ServerInput::TEST)
+		|| input.hasThisFlag(ServerInput::TEST_PRINT))
+	{
+		if (config.isConfigOK())
+			std::cout << PURPLE "<WebServ> " << RESET "Test finished: "
+					  << GREEN BOLD "Config OK!" RESET << std::endl;
+		if (input.hasThisFlag(ServerInput::TEST_PRINT))
+			config.printConfig();
+		return true;
+	}
+	return false;
+}
 
 int main(int argc, char *argv[])
 {
 	try
 	{
-		// Handle the input flags and the config file
+		// Handle the input flags and the config file path
 		ServerInput input(argc, argv);
-		// If the user asked for help, print the help message
-		if (input.hasThisFlag(ServerInput::HELP))
-		{
-			std::cout << input.getHelpMessage() << std::endl;
-		}
-		// If the user asked for the version, print the version message
-		if (input.hasThisFlag(ServerInput::V_LITE)
-			|| input.hasThisFlag(ServerInput::V_FULL))
-		{
-			std::cout << input.getVersionMessage() << std::endl;
-		}
-		// Open and parse the config file, if the user ask for a test of the
-		// config file, the parseFile method will work in test mode.
+		if (isHelpOrVersionFlags(input))
+			return 0;
+		// Config file parser. With test flags on the parseFile method will work
+		// in test mode.
 		ServerConfig config(input.getFilePath());
 		config.parseFile(
 			input.hasThisFlag(ServerInput::TEST),
 			input.hasThisFlag(ServerInput::TEST_PRINT)
 		);
-		// If the user asked for a test of the config file, print the config and
-		// exit
-		if (input.hasThisFlag(ServerInput::TEST)
-			|| input.hasThisFlag(ServerInput::TEST_PRINT))
-		{
-			if (config.isConfigOK())
-				std::cout << PURPLE "<WebServ> " << RESET "Test finished: "
-						  << GREEN BOLD "Config OK!" RESET << std::endl;
-			if (input.hasThisFlag(ServerInput::TEST_PRINT))
-				config.printConfig();
+		if (isTestMode(input, config))
 			return 0;
-		}
 		// Set the log level
 		Logger::setLevel(config.getGeneralConfigValue("error_log"));
-
+		// Set the signals handler
+		signals::handleSignals();
 		// Init and start the server(s)
 		ServerEngine engine(config.getAllServersConfig());
 		engine.start();

--- a/srcs/signals.cpp
+++ b/srcs/signals.cpp
@@ -1,0 +1,74 @@
+#include "signals.hpp"
+#include "Logger.hpp"
+
+#include <csignal>
+#include <cstdlib>
+#include <iostream>
+
+namespace signals
+{
+
+static void handleInterrupt(int signal)
+{
+	if (signal == SIGINT)
+	{
+		std::cout << '\n';
+		Logger::log(Logger::DEBUG)
+			<< "SIGINT received. Exiting..." << std::endl;
+		std::exit(signal);
+	}
+}
+
+static void handleQuit(int signal)
+{
+	if (signal == SIGQUIT)
+	{
+		Logger::log(Logger::DEBUG)
+			<< "SIGQUIT received. Exiting..." << std::endl;
+		std::exit(signal);
+	}
+}
+
+static void handleTerminate(int signal)
+{
+	if (signal == SIGTERM)
+	{
+		Logger::log(Logger::DEBUG)
+			<< "SIGTERM received. Exiting..." << std::endl;
+		std::exit(signal);
+	}
+}
+
+// TODO: Implement the SIGHUP signal to change the status from a global
+// variable to restart the config and servers.
+static void handleHangup(int signal)
+{
+	if (signal == SIGHUP)
+	{
+		Logger::log(Logger::DEBUG)
+			<< "SIGHUP received. Reloading the configuration file and "
+			   "restarting the server..."
+			<< std::endl;
+	}
+}
+
+static void handlePipe(int signal)
+{
+	if (signal == SIGPIPE)
+	{
+		Logger::log(Logger::DEBUG)
+			<< "SIGPIPE received. Client disconnected unexpectedly."
+			<< std::endl;
+	}
+}
+
+void handleSignals(void)
+{
+	std::signal(SIGINT, handleInterrupt);
+	std::signal(SIGQUIT, handleQuit);
+	std::signal(SIGTERM, handleTerminate);
+	std::signal(SIGHUP, handleHangup);
+	std::signal(SIGPIPE, handlePipe);
+}
+
+} // namespace signals


### PR DESCRIPTION
Basic signal handler using exit() to allow the classes to clean up everything properly.

TODO: It seems that in some cases, when using exit(), the classes may not have enough time to close all file descriptors correctly. We may also need to implement a global flag to stop the server and shut down in a good way.