### PR TITLE
Feat: add setRoot() to Server class, and setRootToAllServers() to Ser…

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -31,6 +31,9 @@ class Server
 	std::vector<std::string>				 getServerName(void) const;
 	std::map<std::string, ConfigValue> const getServerConfig(void) const;
 
+	// Setters
+	void setRoot(const std::string &root);
+
 	unsigned int	   getServerIndex(void) const;
 	int const		  &getServerFd(void) const;
 	sockaddr_in const &getServerAddr(void) const;

--- a/include/ServerConfig.hpp
+++ b/include/ServerConfig.hpp
@@ -28,23 +28,24 @@ class ServerConfig
 	void parseFile(bool isTest = false, bool isTestPrint = false);
 	void printConfig(void);
 
+	// Getters
 	// Get the value of a key in the general configuration map.
 	std::string getGeneralConfigValue(std::string const &key) const;
-
 	// Get all servers stored in a vector of maps.
 	bool getAllServersConfig(
 		std::vector<std::map<std::string, ConfigValue> > &serversConfig
 	) const;
-
-	std::vector<std::map<std::string, ConfigValue> > const &getAllServersConfig(void
-	) const;
-
+	std::vector<std::map<std::string, ConfigValue> > const &
+	getAllServersConfig(void) const;
 	// Get the value of a key in a server[serverIndex] configuration map.
 	bool getServerConfigValue(
 		unsigned int	   serverIndex,
 		std::string const &key,
 		ConfigValue		  &value
 	) const;
+
+	// Setters
+	void setRootToAllServers(std::string const &root);
 
 	static std::array<std::string, 4> const validLogLevels;
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -1,7 +1,7 @@
 #include "Server.hpp"
+#include "Logger.hpp"
 #include "ServerException.hpp"
 #include "utils.hpp"
-#include "Logger.hpp"
 
 #include <fcntl.h>
 #include <netdb.h>
@@ -62,7 +62,7 @@ Server::~Server(void)
 	// to indicate that the socket is closed
 	if (serverFd_ >= 0)
 	{
-    this->closeServer();
+		this->closeServer();
 	}
 }
 
@@ -333,4 +333,9 @@ bool Server::getThisLocationValue(
 		return false;
 	}
 	return true;
+}
+
+void Server::setRoot(const std::string &root)
+{
+	root_ = root;
 }

--- a/srcs/ServerConfig.cpp
+++ b/srcs/ServerConfig.cpp
@@ -693,3 +693,12 @@ bool ServerConfig::getServerConfigValue(
 	}
 	return false;
 }
+
+void ServerConfig::setRootToAllServers(std::string const &root)
+{
+	std::vector<std::map<std::string, ConfigValue> >::iterator it(
+		this->serversConfig_.begin()
+	);
+	for (; it != this->serversConfig_.end(); ++it)
+		it->find("root")->second.setVector(std::vector<std::string>(1, root));
+}


### PR DESCRIPTION
- setRoot() is in each server instance. It is now possible to modify the root by modifying each server instance.
- For testing, it is better to modify the root from the ServerConfig instance. Now, you can modify the root for all server configurations using the setRootToAllServers() method inside the ServerConfig class.