### PR TITLE
feat(parser): add header acceptance check

### DIFF
--- a/include/RequestParser.hpp
+++ b/include/RequestParser.hpp
@@ -65,8 +65,4 @@ class RequestParser
 		const std::string &headerName,
 		const std::string &headerValue
 	);
-
-	static const std::string repeatableHeaders[20];
-	static const std::string semicolonSeparated[5];
-	static const std::map<std::string, std::string> headerAcceptedChars_;
 };

--- a/include/request_parser/HeaderParser.hpp
+++ b/include/request_parser/HeaderParser.hpp
@@ -24,6 +24,7 @@ class HeaderParser
 	checkRawHeaders_(const std::multimap<std::string, std::string> &headers);
 	static bool checkRepeatedHeaderAllowed_(std::string header);
 	static void checkSingleHeader_(std::string &headerLine);
+	static bool checkIfHeaderAccepted_(std::string &headerName);
 	static bool isValidHeaderName_(std::string headerName);
 	static bool isValidHeaderValue_(std::string headerValue);
 	// clang-format off

--- a/tests/RequestParserTest.cpp
+++ b/tests/RequestParserTest.cpp
@@ -381,3 +381,26 @@ Test(RequestParser, testHeaderWithWrongSeparator)
 
 	cr_assert_throw(RequestParser::parseRequest(requestStr), HttpException);
 }
+
+Test(RequestParser, testIgnoredHeader)
+{
+	std::string										method("GET");
+	std::string										httpVersion("HTTP/1.1");
+	std::string										host("");
+	std::string										uri("/localhost:8080");
+	std::map<std::string, std::vector<std::string>> headers;
+	headers["Host"].push_back("www.example.com");
+	headers["Proxy-Authenticate"].push_back(
+		"testcontent"
+	);
+	std::vector<char> body;
+
+	std::string requestStr
+		= createRequestString(method, uri, httpVersion, headers, body);
+
+	HttpRequest request = RequestParser::parseRequest(requestStr);
+
+	cr_assert_eq(
+		request.getHeaders().count("Proxy-Authenticate"), 0
+	);
+}

--- a/todo-manu.md
+++ b/todo-manu.md
@@ -5,13 +5,14 @@
    - [ ] Check: what to do with unfolded headers (headers that continue on next line for readability. The next line starts with whitespace. They should be appended.)
    - [ ] Check: URI schemes
    - [ ] Check: Set-Cookie header may be repeated and is a special case
-   - [ ] Implement: filter parser to only check for accpted methods 
    - [ ] Implement: check presence of Content-Length header in POST and its absense in GET and DELETE (double-check these rules!!) 
+   - [ ] Implement: compare request length with limit set in congif
 
    ## In Progress
-   - [ ] Implement: measure body length and set in private attr, and compare with header if any and also add check in response handler for if it exceeds limit in config file
+   - [ ] Implement: filter parser to only check for accepted headers 
 
    ## Done
+   - [x] Implement: measure body length and set in private attr
    - [x] Implement: host_ var in HttpRequest
    - [x] Implement: token syntax 
         - [x] Implement: add check for header with wrong separator (, or ;) 


### PR DESCRIPTION
- Added `checkIfHeaderAccepted_` method to filter headers.
- Updated `parseHeaders` to ignore unaccepted headers.
- Trimmed trailing spaces from header values.
- Added unit test `testIgnoredHeader` to verify ignored headers.