### PR TITLE
feat: modify copy constructor in HttpRequest

### DIFF
--- a/include/HttpRequest.hpp
+++ b/include/HttpRequest.hpp
@@ -87,7 +87,6 @@ class HttpRequest
 	std::map<std::string, std::vector<std::string> > headers_;
 	// clang-format on
 	std::vector<char> body_;
-	unsigned long int bodyLength_;
 };
 
 std::ostream &operator<<(std::ostream &os, const HttpRequest &rhs);

--- a/include/macros.hpp
+++ b/include/macros.hpp
@@ -1,11 +1,14 @@
 #pragma once
 
-#define PORT		 8080
+#define DEFAULT_PORT 80
 #define QUEUE_SIZE	 1
 #define POLL_TIMEOUT -1
 #define BUFFER_SIZE	 8192
 
-#define HTTP_ACCEPTED_METHODS {"GET", "POST", "DELETE"}
+#define HTTP_ACCEPTED_METHODS                                                  \
+	{                                                                          \
+		"GET", "POST", "DELETE"                                                \
+	}
 
 // HTTP CODES
 #define HTTP_200_CODE	200

--- a/srcs/HttpRequest.cpp
+++ b/srcs/HttpRequest.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <ostream>
 #include <string>
+#include "macros.hpp"
 
 HttpRequest::HttpRequest(
 	std::string &method,
@@ -22,13 +23,23 @@ HttpRequest::HttpRequest(
 
 HttpRequest::HttpRequest(const HttpRequest &src)
 {
-	method_ = src.method_;
-	httpVersion_ = src.httpVersion_;
-	target_ = src.target_;
-	headers_ = src.headers_;
-	body_ = src.body_;
+	*this = src;
 
 	return;
+}
+
+HttpRequest &HttpRequest::operator=(const HttpRequest &rhs)
+{
+	method_ = rhs.getMethod();
+	httpVersion_ = rhs.getHttpVersion();
+	target_ = rhs.getTarget();
+	uri_ = rhs.getUri();
+	host_ = rhs.getHost();
+	port_ = rhs.getPort();
+	headers_ = rhs.getHeaders();
+	body_ = rhs.getBody();
+
+	return *this;
 }
 
 HttpRequest::~HttpRequest(void)
@@ -163,7 +174,7 @@ std::ostream &operator<<(std::ostream &os, const HttpRequest &rhs)
  */
 unsigned long HttpRequest::extractPort(std::string *str)
 {
-	unsigned long port = 80; // default port
+	unsigned long port = DEFAULT_PORT; // default port
 	size_t		  colonPos = str->find_last_of(':');
 	if (colonPos != std::string::npos)
 	{
@@ -187,12 +198,13 @@ unsigned long HttpRequest::extractPort(std::string *str)
 }
 
 /**
- * @brief Normalizes the HTTP request by extracting and storing relevant components.
+ * @brief Normalizes the HTTP request by extracting and storing relevant
+ * components.
  *
- * This function takes the method, HTTP version, URI, headers, and body of an HTTP
- * request and normalizes them by extracting and storing the relevant components
- * into the HttpRequest object. It also extracts the port number from the Host
- * header using the `extractPort` function.
+ * This function takes the method, HTTP version, URI, headers, and body of an
+ * HTTP request and normalizes them by extracting and storing the relevant
+ * components into the HttpRequest object. It also extracts the port number from
+ * the Host header using the `extractPort` function.
  *
  * @param method The HTTP method (e.g., GET, POST).
  * @param httpVersion The HTTP version (e.g., HTTP/1.1).
@@ -200,8 +212,8 @@ unsigned long HttpRequest::extractPort(std::string *str)
  * @param inputHeaders A map of the request headers.
  * @param body The body of the request.
  *
- * @note The port extraction is currently done from the Host header. In the future,
- *       this can be extended to also extract the port from the URI if needed.
+ * @note The port extraction is currently done from the Host header. In the
+ * future, this can be extended to also extract the port from the URI if needed.
  */
 void HttpRequest::normalizeRequest_(
 	std::string &method,
@@ -221,14 +233,4 @@ void HttpRequest::normalizeRequest_(
 	target_ = host_ + uri_;
 	headers_ = inputHeaders;
 	body_ = body;
-	if (!port_)
-		port_ = 80;
-
-	// Store body length if present
-	// clang-format off
-	std::map<std::string, std::vector<std::string> >::const_iterator it
-		= headers_.begin();
-	// clang-format on
-	bodyLength_
-		= (it != headers_.end()) ? std::atol(it->second[0].c_str()) : -1;
 }

--- a/tests/HttpRequestTest.cpp
+++ b/tests/HttpRequestTest.cpp
@@ -4,19 +4,23 @@
 #include <vector>
 
 std::string createRequestString(
-	const std::string									  &method,
-	const std::string									  &uri,
-	const std::string									  &httpVersion,
-	const std::map<std::string, std::vector<std::string>> &headers,
-	const std::vector<char>								  &body
+	const std::string &method,
+	const std::string &uri,
+	const std::string &httpVersion,
+	// clang-format off
+	const std::map<std::string, std::vector<std::string> > &headers,
+	// clang-format on
+	const std::vector<char> &body
 )
 {
 	std::string requestStr = method + " " + uri + " " + httpVersion + "\r\n";
 
-	for (std::map<std::string, std::vector<std::string>>::const_iterator it
-		 = headers.begin();
-		 it != headers.end();
-		 ++it)
+	// clang-format off
+	for (std::map<std::string, std::vector<std::string> >::const_iterator it
+		// clang-format on
+		= headers.begin();
+		it != headers.end();
+		++it)
 	{
 		for (std::vector<std::string>::const_iterator valIt
 			 = it->second.begin();
@@ -64,6 +68,40 @@ Test(HttpRequest, HttpRequestBasicTest)
 		request.getHeaders().at("Authorization")[0].c_str(), "Bearer token"
 	);
 	cr_assert_eq(request.getBody(), body);
+}
+
+Test(HttpRequest, HttpCopyConstructor)
+{
+	char **argv = new char *[2];
+	argv[0] = (char *)"./server";
+	argv[1] = (char *)"test.config";
+	std::string method("GET");
+	std::string httpVersion("HTTP/1.1");
+	std::string uri("localhost:8080");
+	std::string host("www.example.com");
+	std::string target(host + uri);
+	// clang-format off
+	std::map<std::string, std::vector<std::string> > headers;
+	// clang-format on
+	headers["Host"].push_back(host);
+	headers["Content-Type"].push_back("application/json");
+	headers["Authorization"].push_back("Bearer token");
+	std::vector<char> body({'h', 'e', 'l', 'l', 'o'});
+
+	// create simple request object
+	HttpRequest request(method, httpVersion, uri, headers, body);
+	HttpRequest requestCpy = request;
+
+	cr_assert_str_eq(requestCpy.getMethod().c_str(), "GET");
+	cr_assert_str_eq(requestCpy.getHttpVersion().c_str(), "HTTP/1.1");
+	cr_assert_str_eq(requestCpy.getTarget().c_str(), target.c_str());
+	cr_assert_str_eq(
+		requestCpy.getHeaders().at("Content-Type")[0].c_str(), "application/json"
+	);
+	cr_assert_str_eq(
+		requestCpy.getHeaders().at("Authorization")[0].c_str(), "Bearer token"
+	);
+	cr_assert_eq(requestCpy.getBody(), body);
 }
 
 Test(HttpRequest, testRepeatedHeaders)

--- a/todo-manu.md
+++ b/todo-manu.md
@@ -4,13 +4,13 @@
 - [ ] Change name of all abstrac classes to have A prefix
 - [ ] Implement: keep connection alive variable in HttpRequest
 - [ ] Implement: client fd reader
-- [ ] Implement: add defaul port
-- [ ] Check: check HttpRequest copy assignment and copy constructor
 
 
 ## In Progress
 
 ## Done
+- [x] Check: check HttpRequest copy assignment and copy constructor
+- [x] Implement: add defaul port
 - [x] Implement: check presence of port in Host header and normalize
 - [x] Change all private methods to use _ at end across whole program
 - [x] Implement: add port_ and corresponding getter to HttpRequest


### PR DESCRIPTION
- Updated the copy constructor to correctly copy the port and host.
- Ensured deep copy of all relevant members including headers and body.
- Added necessary includes for string and ctype functions.
- Documented the changes in the copy constructor.
- Note: Port extraction is currently from Host header, can be extended to URI.