### PR TITLE
fix(config): comment out root directive in CGI location

### DIFF
--- a/default.config
+++ b/default.config
@@ -62,7 +62,7 @@ http {
         # Define a location that uses CGI scripts.
 				location /with-cgi {
 						# Redife the root directory for this location.
-						root /;
+						# root /;
 						# Define the CGI script extension and the interpreter to use.
 						cgi .py /usr/bin/python3;
 				}


### PR DESCRIPTION
- Commented out the `root` directive in the `/with-cgi` location block.
- Added `.gitkeep` file to `www/website/uploads` to ensure directory is tracked.