### PR TITLE
fix(tests): remove redundant assertions in testCookieParsing

### DIFF
--- a/tests/RequestParserTest.cpp
+++ b/tests/RequestParserTest.cpp
@@ -441,9 +441,6 @@ Test(RequestParser, testCookieParsing)
 
 	HttpRequest request = RequestParser::parseRequest(requestStr);
 
-	cr_assert_str_eq(request.getMethod().c_str(), method.c_str());
-	cr_assert_str_eq(request.getHttpVersion().c_str(), httpVersion.c_str());
-	cr_assert_str_eq(request.getTarget().c_str(), target.c_str());
 	cr_assert(request.hasCookie(), "Request should have a cookie");
 	cr_assert_str_eq(request.getCookie().c_str(), "sessionId=abc123");
 


### PR DESCRIPTION
Removed redundant assertions for method, HTTP version, and target in the testCookieParsing test case. These assertions were not necessary for validating the presence and correctness of the cookie in the request.