### PR TITLE
fix(warnings): suppress deprecation warnings in scripts

### DIFF
--- a/www/instagram-clone/cgi/post.py
+++ b/www/instagram-clone/cgi/post.py
@@ -1,3 +1,6 @@
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
 import os
 import cgi
 import logging

--- a/www/instagram-clone/home.py
+++ b/www/instagram-clone/home.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
 import os
 import cgi
 


### PR DESCRIPTION
Added warnings.filterwarnings to suppress deprecation warnings in post.py and home.py scripts. This change ensures that deprecation warnings are not printed when running these scripts, improving the readability of the output and preventing unnecessary warnings from cluttering the logs.